### PR TITLE
Adding project monthly report template

### DIFF
--- a/process/Project-Monthly-Report-Template.md
+++ b/process/Project-Monthly-Report-Template.md
@@ -1,23 +1,30 @@
-# (Name of Project) Monthly Report (Current Month Year)
-
-## Prepared By
-
-
-## Overview
+1. Summary
+- Title of project
+- Date of report (2022-12-31)
+- Prepared by 
 
 
-## Activities and progress since last report
+2. Activities and progress since last report
+- Planned
+- Unplanned
 
 
-## Issues and Difficulties
+3. Issues and Difficulties
+- Bullet point issues and difficulties
 
 
-## Timeline
+4. Timeline and statistics
+- Examples:
+  - Task completion status (Kanban chart)
+  - Timeline (likely only for resourced projects)
+  - Regression test results
+  - Issue tracker statistics
+  - Risk register update
 
 
-### Gate status & schedule
+5. Gate status & schedule
 
-|	Gate	| Original plan	| Current plan	| Achieved  	| Link to gate document  																		|
+|	Gate	| Original plan	| Current plan	| Achieved  	| Link to last gate document  																		|
 |	---	| ----------	| ----------	| ----------	| ----------------------																		|
 |	PC	| 2022-01-31	| 2022-01-31	| 2022-01-31	| [QEMU PC](https://github.com/openhwgroup/programs/blob/master/Project-Descriptions-and-Plans/CORE-V-QEMU/QEMU-Project-Concept.md)	|
 |	PL	|			|			|	    		|																						|

--- a/process/Project-Monthly-Report-Template.md
+++ b/process/Project-Monthly-Report-Template.md
@@ -1,0 +1,26 @@
+# (Name of Project) Monthly Report (Current Month Year)
+
+## Prepared By
+
+
+## Overview
+
+
+## Activities and progress since last report
+
+
+## Issues and Difficulties
+
+
+## Timeline
+
+
+### Gate status & schedule
+
+|	Gate	|	Target	|	Achieved  	| Link to gate document  																		|
+|	---	|	----------	|     ----------	| ----------------------																		|
+|	PC	|	2022-01-31	|	2022-01-31	| [QEMU PC](https://github.com/openhwgroup/programs/blob/master/Project-Descriptions-and-Plans/CORE-V-QEMU/QEMU-Project-Concept.md)	|
+|	PL	|			|		    	|																						|
+|	PA	|			|		    	|																						|
+|	PF	|			|		    	|																						|
+

--- a/process/Project-Monthly-Report-Template.md
+++ b/process/Project-Monthly-Report-Template.md
@@ -17,10 +17,10 @@
 
 ### Gate status & schedule
 
-|	Gate	|	Target	|	Achieved  	| Link to gate document  																		|
-|	---	|	----------	|     ----------	| ----------------------																		|
-|	PC	|	2022-01-31	|	2022-01-31	| [QEMU PC](https://github.com/openhwgroup/programs/blob/master/Project-Descriptions-and-Plans/CORE-V-QEMU/QEMU-Project-Concept.md)	|
-|	PL	|			|		    	|																						|
-|	PA	|			|		    	|																						|
-|	PF	|			|		    	|																						|
+|	Gate	| Original plan	| Current plan	| Achieved  	| Link to gate document  																		|
+|	---	| ----------	| ----------	| ----------	| ----------------------																		|
+|	PC	| 2022-01-31	| 2022-01-31	| 2022-01-31	| [QEMU PC](https://github.com/openhwgroup/programs/blob/master/Project-Descriptions-and-Plans/CORE-V-QEMU/QEMU-Project-Concept.md)	|
+|	PL	|			|			|	    		|																						|
+|	PA	|			|		    	|		    	|																						|
+|	PF	|			|		    	|		    	|																						|
 


### PR DESCRIPTION
This template will be used by each project to create a concise report that will live in the appropriate task group folder in the programs repo. The template has a link to the project gate information for that project with schedule. 