### PR TITLE
Attendance for Software TG meeting 8 May 2023

### DIFF
--- a/TWG-and-TG-Attendance-Tracking/TGSoftware_Attendance_2023.md
+++ b/TWG-and-TG-Attendance-Tracking/TGSoftware_Attendance_2023.md
@@ -6,78 +6,78 @@ odd-numbered months.
 
 **Software TG Member Attendance Table**
 
-| Company                |  Person               |23.03.13|23.01.09|23.MM.DD|
-|------------------------|-----------------------|:------:|:------:|:------:|
-| Alibaba Group          | David Chen            |        |        |        |
-| Alibaba Group          | Vincent Chu           |        |        |        |
-| Alibaba Group          | Yunhai Shang          |        |        |        |
-| Amazon                 | Joseph Julicher       |        | Y      |        |
-| Amazon                 | Richard Barry         |        |        |        |
-| Ashling Micro. Ltd     | Hugh O'Keeffe         |        |        |        |
-| Ashling Micro. Ltd     | Promodkumar CM        | Y      | Y      |        |
-| Ashling Micro. Ltd     | Rejeesh SB            |        |        |        |
-| CAS PLCT Lab           | Chunyu Liao           |        |        |        |
-| CAS PLCT Lab           | Jiawei Chen           |        |        |        |
-| CAS PLCT Lab           | Liao Shihua           |        |        |        |
-| CAS PLCT Lab           | Mingjie Xing          | Y      |        |        |
-| CAS PLCT Lab           | Qihan Cai             |        |        |        |
-| CAS PLCT Lab           | Yulong Shi            |        |        |        |
-| CAS PLCT Lab           | Wei Wu                |        |        |        |
-| CAS PLCT Lab           | Weiwei Li             | Y      | Y      |        |
-| CAS PLCT Lab           | Wu Xinlong            |        |        |        |
-| CMC Microsystems       | Hugh Pollitt-Smith    |        |        |        |
-| CMC Microsystems       | Olive Zhao            |        | Y      |        |
-| Codeplay               | Michael Wong          |        |        |        |
-| Dolphin Design         | Pascal Gouedo         |        | Y      |        |
-| Embecosm               | Jeremy Bennett        | Y      | Y      |        |
-| Embecosm               | Mary Bennett          |        | Y      |        |
-| Embecosm               | Hélène Chelin         |        | Y      |        |
-| Embecosm               | Nandni Jamnadas       | Y      | Y      |        |
-| Embecosm               | Charlie Keaney        | Y      | Y      |        |
-| Embecosm               | Shteryana Shopova     |        |        |        |
-| EMUS                   | John Martin           |        |        |        |
-| ETH Zürich             | Robert Balas          |        |        |        |
-| Imperas                | Simon Davidmann       |        |        |        |
-| Imperas                | Kevin McDermott       |        |        |        |
-| Imperas                | Lee Moore             |        |        |        |
-| Futurewei              | Jingliang (Leo) Wang  |        |        |        |
-| NXP USA, Inc.          | Jerry Zeng            |        |        |        |
-| Quicklogic             | Greg Martin           |        |        |        |
-| Quicklogic             | Tim Saxe              |        |        |        |
-| RT-Thread              | Cathy Lee             | Y      |        |        |
-| RT-Thread              | Henson                | Y      |        |        |
-| RT-Thread              | Wang Shun             | Y      |        |        |
-| Silicon Labs. Inc.     | Arjan Bink            |        |        |        |
-| Thales                 | Zbigniew Chamski      |        |        |        |
-| Thales                 | Anjali Indrapal Gedam |        |        |        |
-| Thales                 | Anjali Verma          | Y      |        |        |
-| Thales                 | Jean-Roch Coulon      |        |        |        |
-| Thales                 | Sébastien Jacq        |        |        |        |
-| Thales                 | André Sintzoff        |        |        |        |
-| Thales                 | Zbigniew Chamski      |        |        |        |
-| Thales                 | Jérôme Quévremont     | Y      |        |        |
-| Univeristy Bologna     | Nazareno Bruschi      |        |        |        |
-| Univeristy Bologna     | Gianmarco Ottavi      |        |        |        |
-| Univeristy Bologna     | Enrico Tabanelli      |        |        |        |
-| Univeristy Bologna     | Giuseppe Tagliavini   |        |        |        |
+| Company                |  Person               |23.05.08|23.03.13|23.01.09|23.MM.DD|
+|------------------------|-----------------------|:------:|:------:|:------:|:------:|
+| Alibaba Group          | David Chen            |        |        |        |        |
+| Alibaba Group          | Vincent Chu           |        |        |        |        |
+| Alibaba Group          | Yunhai Shang          |        |        |        |        |
+| Amazon                 | Joseph Julicher       | Y      |        | Y      |        |
+| Amazon                 | Richard Barry         |        |        |        |        |
+| Ashling Micro. Ltd     | Hugh O'Keeffe         |        |        |        |        |
+| Ashling Micro. Ltd     | Promodkumar CM        | Y      | Y      | Y      |        |
+| Ashling Micro. Ltd     | Rejeesh SB            |        |        |        |        |
+| CAS PLCT Lab           | Chunyu Liao           |        |        |        |        |
+| CAS PLCT Lab           | Jiawei Chen           |        |        |        |        |
+| CAS PLCT Lab           | Liao Shihua           |        |        |        |        |
+| CAS PLCT Lab           | Mingjie Xing          |        | Y      |        |        |
+| CAS PLCT Lab           | Qihan Cai             |        |        |        |        |
+| CAS PLCT Lab           | Yulong Shi            |        |        |        |        |
+| CAS PLCT Lab           | Wei Wu                | Y      |        |        |        |
+| CAS PLCT Lab           | Weiwei Li             |        | Y      | Y      |        |
+| CAS PLCT Lab           | Wu Xinlong            |        |        |        |        |
+| CMC Microsystems       | Hugh Pollitt-Smith    |        |        |        |        |
+| CMC Microsystems       | Olive Zhao            |        |        | Y      |        |
+| Codeplay               | Michael Wong          |        |        |        |        |
+| Dolphin Design         | Pascal Gouedo         |        |        | Y      |        |
+| Embecosm               | Jeremy Bennett        | Y      | Y      | Y      |        |
+| Embecosm               | Mary Bennett          |        |        | Y      |        |
+| Embecosm               | Hélène Chelin         |        |        | Y      |        |
+| Embecosm               | Nandni Jamnadas       |        | Y      | Y      |        |
+| Embecosm               | Charlie Keaney        | Y      | Y      | Y      |        |
+| Embecosm               | Shteryana Shopova     |        |        |        |        |
+| EMUS                   | John Martin           |        |        |        |        |
+| ETH Zürich             | Robert Balas          |        |        |        |        |
+| Imperas                | Simon Davidmann       |        |        |        |        |
+| Imperas                | Kevin McDermott       |        |        |        |        |
+| Imperas                | Lee Moore             |        |        |        |        |
+| Futurewei              | Jingliang (Leo) Wang  |        |        |        |        |
+| NXP USA, Inc.          | Jerry Zeng            |        |        |        |        |
+| Quicklogic             | Greg Martin           |        |        |        |        |
+| Quicklogic             | Tim Saxe              |        |        |        |        |
+| RT-Thread              | Cathy Lee             |        | Y      |        |        |
+| RT-Thread              | Henson                |        | Y      |        |        |
+| RT-Thread              | Wang Shun             |        | Y      |        |        |
+| Silicon Labs. Inc.     | Arjan Bink            |        |        |        |        |
+| Thales                 | Zbigniew Chamski      |        |        |        |        |
+| Thales                 | Anjali Indrapal Gedam | Y      |        |        |        |
+| Thales                 | Anjali Verma          |        | Y      |        |        |
+| Thales                 | Jean-Roch Coulon      |        |        |        |        |
+| Thales                 | Sébastien Jacq        |        |        |        |        |
+| Thales                 | André Sintzoff        |        |        |        |        |
+| Thales                 | Zbigniew Chamski      |        |        |        |        |
+| Thales                 | Jérôme Quévremont     |        | Y      |        |        |
+| Univeristy Bologna     | Nazareno Bruschi      |        |        |        |        |
+| Univeristy Bologna     | Gianmarco Ottavi      |        |        |        |        |
+| Univeristy Bologna     | Enrico Tabanelli      |        |        |        |        |
+| Univeristy Bologna     | Giuseppe Tagliavini   |        |        |        |        |
 
 **Guest/Non-Member Attendance Table**
 
-| Company                |  Person               |23.03.13|23.01.09|23.MM.DD|
-|------------------------|-----------------------|:------:|:------:|:------:|
-| Eclipse project        | Alexander Fedorov     |        |        |        |
-| Eclipse project        | Frédŕic Desbiens      |        |        |        |
-| Eclipse project        | Brian King            |        |        |        |
-| Publitek               | Andrea Barnard        |        |        |        |
-| University Tübingen    | Christoph Gerum       |        |        |        |
-| University Tübingen    | Serkan Muhcu          |        |        |        |
+| Company                |  Person               |23.05.08|23.03.13|23.01.09|23.MM.DD|
+|------------------------|-----------------------|:------:|:------:|:------:|:------:|
+| Eclipse project        | Alexander Fedorov     |        |        |        |        |
+| Eclipse project        | Frédŕic Desbiens      |        |        |        |        |
+| Eclipse project        | Brian King            |        |        |        |        |
+| Publitek               | Andrea Barnard        |        |        |        |        |
+| University Tübingen    | Christoph Gerum       |        |        |        |        |
+| University Tübingen    | Serkan Muhcu          |        |        |        |        |
 
 **OpenHW Attendance Table**
 
-| Company                |  Person               |23.03.13|23.01.09|23.MM.DD|
-|------------------------|-----------------------|:------:|:------:|:------:|
-| OpenHW                 | Duncan Bees           | Y      | Y      |        |
-| OpenHW                 | Rick O'Connor         |        |        |        |
-| OpenHW                 | Davide Schiavone      |        |        |        |
-| OpenHW                 | Mike Thompson         | Y      | Y      |        |
-| OpenHW                 | Florian Zaruba        |        |        |        |
+| Company                |  Person               |23.05.08|23.03.13|23.01.09|23.MM.DD|
+|------------------------|-----------------------|:------:|:------:|:------:|:------:|
+| OpenHW                 | Duncan Bees           | Y      | Y      | Y      |        |
+| OpenHW                 | Rick O'Connor         |        |        |        |        |
+| OpenHW                 | Davide Schiavone      |        |        |        |        |
+| OpenHW                 | Mike Thompson         | Y      | Y      | Y      |        |
+| OpenHW                 | Florian Zaruba        |        |        |        |        |


### PR DESCRIPTION
TWG-and-TG-Attendance-Tracking/

	* TGSoftware_Attendance_2023.md: Updated with attendance from 8 May 2023.