### PR TITLE
Fix markdown formatting

### DIFF
--- a/Project-Descriptions-and-Plans/CV32E40Pv2/Milestone-data/README.md
+++ b/Project-Descriptions-and-Plans/CV32E40Pv2/Milestone-data/README.md
@@ -1,14 +1,15 @@
+## DRAFT DRAFT DRAFT
+This is **_not_** a final report.  It is here to faciliate reviews.
+
 ### TRL-5 Checklists and Reports for the CV32E40P v2
-The OpenHW Group asserts that the documentation, implementation and verification of the CV32E40P v2.0.0 meets the criteria for TBD <Technical Readiness Level ?>.\
+The OpenHW Group asserts that the documentation, implementation and verification of the CV32E40P v2.0.0 meets the criteria for Technical Readiness Level 5.
 The directories and files below this point store the completed checklists, reports (and waivers) in support of this claim.
 
 **RTL_Freeze_v2.0.0** :
-    |- OpenHWGroup_TRL5_for_COREV_RTL_Cheklist-CV32E40P.xls: checklists for the v2.0.0 tag of CV32E40P.\
-    |- CV32E40Pv2_regression_known_failure.xls\
-    |- CV32E40Pv2_uncovered_coverage_explanation.xls\
-    |- CV32E40Pv2_waiver_list.xls\
-    |- Reports : RTL Code Coverage, Functional coverage, Formal, RISCOF and Simulation Regression reports in support of RTL Freeze.\
-    <ul>
-        |- index.html : start from this file. It presents all quick links to directly jump to information.\
-        |- 2024-05-06 : contains the reports for RTL tag cv32e40p_v1.8.1\
-    </ul>
+- OpenHWGroup_TRL5_for_COREV_RTL_Cheklist-CV32E40P.xls: checklists for the v2.0.0 tag of CV32E40P.
+- CV32E40Pv2_regression_known_failure.xls
+- CV32E40Pv2_uncovered_coverage_explanation.xls
+- CV32E40Pv2_waiver_list.xls
+- Reports : RTL Code Coverage, Functional coverage, Formal, RISCOF and Simulation Regression reports in support of RTL Freeze.
+  - index.html : start from this file. It presents all quick links to directly jump to information.
+  - 2024-05-06 : contains the reports for RTL tag cv32e40p_v1.8.1


### PR DESCRIPTION
GitHub markdown is a little different from "conventional" markdown, so this README was not rendering properly.  This pull-request fixes that and also makes it clear that the CV32E40P v2.0.0 Milestone-data is still in draft form.