### PR TITLE
Set Ubuntu runner image to latest (20.04) no longer supported

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-latest"
   tools:
     python: "3.9"
 


### PR DESCRIPTION
Update in reaction to message from GitHub:
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.

Yes, this update is for ReadTheDocs, but it is expected that the same issue will happen at RTD as well.